### PR TITLE
[8.x.x] o-combo: the height of the o-combo is not same than other input component 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+# 8.2.2
+### Bug fixes
+* **o-combo**: Fixed the height of the o-combo is not same than other input component with theme lite ([8d6024a](https://github.com/OntimizeWeb/ontimize-web-ngx-theming/commit/8d6024a)) Closes [#53](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/53)
+
 # 8.2.1 (2022-03-22)
-### Bugfix
+### Bug fixes
 * Fixing bug in input placeholder overlapping ([34ecd5d](https://github.com/OntimizeWeb/ontimize-web-ngx-theming/commit/34ecd5d))
 * **Fashion theme**
   * Fixed hover styles in the buttons with class mat-accent ([6d8d9e](https://github.com/OntimizeWeb/ontimize-web-ngx-theming/commit/6d8d9e))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontimize-web-ngx-theming",
-  "version": "8.3.0-SNAPSHOT-0",
+  "version": "8.2.2-SNAPSHOT-0",
   "description": "An implementation of themes manager for Ontimize Web applications",
   "scripts": {
     "rimraf": "rimraf",

--- a/src/styles/lite/form-field/o-form-field-theme.scss
+++ b/src/styles/lite/form-field/o-form-field-theme.scss
@@ -132,8 +132,7 @@
       top: calc(100% - #{$wrapper-padding-bottom / $subscript-font-scale});
     }
   }
-
-
+  @include o-combo();
   @include o-mat-checkbox-typography($config);
   @include o-mat-form-field-legacy-typography($config);
   @include o-mat-form-field-fill-typography($config);
@@ -170,5 +169,16 @@
       height: $mat-checkbox-size;
     }
 
+  }
+}
+
+/*
+  Fixes https://github.com/OntimizeWeb/ontimize-web-ngx-theming/issues/53
+   set line-height to normal as user-agent set in the inputs
+   https://bugzilla.mozilla.org/show_bug.cgi?id=349259
+*/
+@mixin o-combo() {
+  .o-combo mat-select {
+    line-height: normal;
   }
 }

--- a/src/styles/lite/typography/ontimize-lite.scss
+++ b/src/styles/lite/typography/ontimize-lite.scss
@@ -42,8 +42,12 @@ $o-mat-lite-typography: mat-typography-config(
   $body-1:        mat-typography-level(12px, 15px, 400),
   $caption:       mat-typography-level(11px, 15px, 400),
   $button:        mat-typography-level(13px, 14px, 500),
-  // Line-height must be unit-less fraction of the font-size.
+  /* Line-height must be unit-less fraction of the font-size
+   but it doesnot work on input because the line-height of the user agent remains
+   https://bugzilla.mozilla.org/show_bug.cgi?id=349259
+   */
   $input:         mat-typography-level(14px, 1, 400)
+
 );
 
 $lite-typography: map-merge($o-mat-lite-typography, $table-typography);


### PR DESCRIPTION
Fixes #53 
Update version to 8.2.2