### PR TITLE
[8.x.x] Replace an invalid pseudo class  `:label-shown` bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.2.2
+### Bug fixes
+* Replace an invalid pseudo class `:label-shown` by a valid `:placeholder-shown` pseudo class ([43d385d](https://github.com/OntimizeWeb/ontimize-web-ngx-theming/commit/43d385d)) Closes [#55](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/55)
+
 # 8.2.1 (2022-03-22)
 ### Bugfix
 * Fixing bug in input placeholder overlapping ([34ecd5d](https://github.com/OntimizeWeb/ontimize-web-ngx-theming/commit/34ecd5d))

--- a/src/styles/lite/form-field/o-form-field-fill-theme.scss
+++ b/src/styles/lite/form-field/o-form-field-fill-theme.scss
@@ -33,7 +33,7 @@
 
       // Server-side rendered matInput with a label attribute but label not shown
       // (used as a pure CSS stand-in for mat-form-field-should-float).
-      .mat-input-server[label]:not(:label-shown) + .mat-form-field-label-wrapper .mat-form-field-label {
+      .mat-input-server[label]:not(:placeholder-shown) + .mat-form-field-label-wrapper .mat-form-field-label {
         @include o_mat-form-field-fill-label-floating( $subscript-font-scale, $infix-padding-top + $fill-appearance-label-offset, $infix-margin-top);
       }
     }

--- a/src/styles/lite/form-field/o-form-field-outline-theme.scss
+++ b/src/styles/lite/form-field/o-form-field-outline-theme.scss
@@ -42,7 +42,7 @@
 
       // Server-side rendered matInput with a label attribute but label not shown
       // (used as a pure CSS stand-in for mat-form-field-should-float).
-      .mat-input-server[label]:not(:label-shown) + .mat-form-field-label-wrapper .mat-form-field-label {
+      .mat-input-server[label]:not(:placeholder-shown) + .mat-form-field-label-wrapper .mat-form-field-label {
         @include o_mat-form-field-outline-label-floating( $subscript-font-scale, $infix-padding + $outline-appearance-label-offset, $infix-margin-top);
       }
     }

--- a/src/styles/lite/form-field/o-form-field-theme.scss
+++ b/src/styles/lite/form-field/o-form-field-theme.scss
@@ -103,7 +103,7 @@
 
       // Server-side rendered matInput with a label attribute but label not shown
       // (used as a pure CSS stand-in for mat-form-field-should-float).
-      .mat-input-server[label]:not(:label-shown) + .mat-form-field-label-wrapper .mat-form-field-label {
+      .mat-input-server[label]:not(:placeholder-shown) + .mat-form-field-label-wrapper .mat-form-field-label {
         @include o_mat-form-field-label-floating( $subscript-font-scale, $infix-padding, $infix-margin-top);
       }
     }


### PR DESCRIPTION
Replace an invalid pseudo class :label-shown by a valid :placeholder-shown pseudo class to correct styles of a form-field label