### PR TITLE
[8.x.x]  Unexpected shorthand "border-radius" after "border-top-right-radius" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+# 8.2.2
+### Bug fixes
+* Fixed unexpected shorthand "border-radius" after "border-top-right-radius" ([fbb8cce](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/fbb8cce)) Closes [#57](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/57)
 # 8.2.1 (2022-03-22)
-### Bugfix
+### Bug fixes
 * Fixing bug in input placeholder overlapping ([34ecd5d](https://github.com/OntimizeWeb/ontimize-web-ngx-theming/commit/34ecd5d))
 * **Fashion theme**
   * Fixed hover styles in the buttons with class mat-accent ([6d8d9e](https://github.com/OntimizeWeb/ontimize-web-ngx-theming/commit/6d8d9e))

--- a/src/styles/ontimize-theme-styles-flat.scss
+++ b/src/styles/ontimize-theme-styles-flat.scss
@@ -219,8 +219,6 @@
   .mat-tab-group.o-tab-ontimize {
     .mat-tab-header .mat-tab-label-container .mat-tab-list .mat-tab-label,
     div.mat-tab-body-wrapper {
-      border-top-left-radius: 0;
-      border-top-right-radius: 0;
       border-radius: 0;
       padding: 0;
     }


### PR DESCRIPTION
Fixed unexpected shorthand "border-radius" after "border-top-right-radius"
Closes #57